### PR TITLE
refactor: Change in the way objects are created

### DIFF
--- a/bin/pireal
+++ b/bin/pireal
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 #
 # Copyright 2015-2019 Gabriel Acosta <acostadariogabriel@gmail.com>
@@ -49,9 +49,9 @@ else:
 if project_base_dir not in sys.path:
     sys.path.insert(0, project_base_dir)
 
-from pireal.core import cliparser
-from pireal import __version__
-from pireal.core import settings
+from pireal.core import cliparser  # noqa
+from pireal import __version__  # noqa
+from pireal.core import settings  # noqa
 
 # Parse CLI
 args = cliparser.get_cli().parse_args()
@@ -63,8 +63,8 @@ if args.version:
 # Creo los dirs antes de leer logs see #84
 create_dirs()
 
-from pireal.core import logger
-from pireal import main
+from pireal.core import logger  # noqa
+from pireal import main  # noqa
 from pireal import resources  # noqa
 # Set up logger
 logger.set_up(args.verbose)

--- a/pireal/core/settings.py
+++ b/pireal/core/settings.py
@@ -120,7 +120,7 @@ class Config(QObject):
         self._settings[option] = value
 
     @staticmethod
-    def _get_font(self):
+    def _get_font():
         font = QFont("consolas", 11)
         if LINUX:
             font = QFont("monospace", 12)

--- a/pireal/gui/database_container.py
+++ b/pireal/gui/database_container.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Pireal; If not, see <http://www.gnu.org/licenses/>.
 
-# import csv
 import logging
 
 from PyQt5.QtWidgets import QSplitter
@@ -42,23 +41,19 @@ from pireal.gui import delegate
 from pireal.gui.query_container import query_container
 from pireal.core import relation
 from pireal.core import pfile
-# from pireal.core import file_manager
 from pireal.core import settings
 
-# from pireal.core.logger import Logger
-
-# logger = Logger(__name__)
 logger = logging.getLogger(__name__)
 
 
 class DatabaseContainer(QSplitter):
 
-    def __init__(self, orientation=Qt.Horizontal):
-        QSplitter.__init__(self, orientation)
+    def __init__(self, parent=None, orientation=Qt.Horizontal):
+        super().__init__(orientation, parent)
         self.pfile = None
-
-        self.lateral_widget = lateral_widget.LateralWidget()
-        self.table_widget = table_widget.TableWidget()
+        self.central = parent
+        self.lateral_widget = lateral_widget.LateralWidget(self)
+        self.table_widget = table_widget.TableWidget(self)
         self.query_container = query_container.QueryContainer(self)
 
         self._vsplitter = QSplitter(Qt.Vertical)
@@ -80,8 +75,7 @@ class DatabaseContainer(QSplitter):
         # see issue #39
         self.lateral_widget.relationSelectionChanged.connect(
             lambda i: self.table_widget.stacked.setCurrentIndex(i))
-        self.query_container.saveEditor.connect(
-            self.save_query)
+        self.query_container.saveEditor.connect(self.save_query)
         self.setSizes([1, 1])
 
     def _on_relation_clicked(self, index):
@@ -159,28 +153,6 @@ class DatabaseContainer(QSplitter):
         # self.lateral_widget.update_item(value)
         self.lateral_widget.relation_list.update_cardinality(value)
 
-    # def load_relation(self, filenames):
-    #     for filename in filenames:
-    #         with open(filename) as f:
-    #             csv_reader = csv.reader(f)
-    #             header = next(csv_reader)
-    #             rel = relation.Relation()
-    #             rel.header = header
-    #             for i in csv_reader:
-    #                 rel.insert(i)
-    #             relation_name = file_manager.get_basename(filename)
-    #             if not self.table_widget.add_relation(relation_name, rel):
-    #                 QMessageBox.information(self, self.tr("Información"),
-    #                                         self.tr("Ya existe una relación "
-    #                                                 "con el nombre  "
-    #                                                 "'{}'".format(
-    #                                                     relation_name)))
-    #                 return False
-
-    #         self.table_widget.add_table(rel, relation_name)
-    #         # self.lateral_widget.add_item(relation_name, rel.cardinality())
-    #         return True
-
     def delete_relation(self):
         name = self.lateral_widget.relation_list.current_text()
         index = self.lateral_widget.relation_list.current_index()
@@ -205,33 +177,12 @@ class DatabaseContainer(QSplitter):
             return True
         return False
 
-    def __on_data_table_changed(self, row, col, data):
-        # current_relation = self.lateral_widget.current_text()
-        # # Relation to be update
-        # rela = self.table_widget.relations.get(current_relation)
-        # # Clear old content
-        # rela.clear()
-        # current_table = self.table_widget.stacked.currentWidget()
-        # model = current_table.model()
-        # for i in range(model.rowCount()):
-        #     reg = []
-        #     for j in range(model.columnCount()):
-        #         if row == i and col == j:
-        #             reg.append(data)
-        #         else:
-        #             reg.append(model.item(i, j).text())
-        #     # Insert new content
-        #     rela.insert(reg)
-        # # Update relation
-        # self.table_widget.relations[current_relation] = rela
-        pass
-
     def new_query(self, filename):
         editor_tab_at = self.query_container.is_open(filename)
         if editor_tab_at != -1:
             self.query_container.set_focus_editor_tab(editor_tab_at)
         else:
-            query_widget = query_container.QueryWidget()
+            query_widget = query_container.QueryWidget(self)
             # Create object file
             ffile = pfile.File(filename)
             editor = query_widget.get_editor()

--- a/pireal/gui/dialogs/edit_relation_dialog.py
+++ b/pireal/gui/dialogs/edit_relation_dialog.py
@@ -30,7 +30,6 @@ from PyQt5.QtGui import QFont
 
 from PyQt5.QtCore import pyqtSignal
 
-from pireal.gui.main_window import Pireal
 from pireal.core.settings import CONFIG
 
 
@@ -40,6 +39,7 @@ class EditRelationDialog(QDialog):
 
     def __init__(self, rname, parent=None):
         super().__init__(parent)
+        self._central = parent
         self._rname = rname
         self.setWindowTitle(self.tr("Editor - {}".format(rname)))
         self.resize(400, 300)
@@ -76,8 +76,7 @@ class EditRelationDialog(QDialog):
         btn_accept.clicked.connect(self._on_accept)
 
     def _on_accept(self):
-        central = Pireal.get_service("central")
-        table_widget = central.get_active_db().table_widget
+        table_widget = self._central.get_active_db().table_widget
         relation = table_widget.relations[self._rname]
         lines = self._editor.toPlainText().splitlines()
         tuples = [tuple(t.split(",")) for t in lines]

--- a/pireal/gui/dialogs/new_relation_dialog.py
+++ b/pireal/gui/dialogs/new_relation_dialog.py
@@ -35,7 +35,7 @@ from pireal import translations as tr
 
 from pireal.core import relation
 from pireal.gui import view
-from pireal.gui.main_window import Pireal
+# from pireal.gui.main_window import Pireal
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,7 @@ class NewRelationDialog(QDialog):
 
     def __init__(self, parent=None):
         QDialog.__init__(self, parent)
+        self._central = parent
         self.setWindowTitle(tr.TR_RELATION_DIALOG_TITLE)
         # self.setModal(True)
         self._data = None
@@ -138,8 +139,8 @@ class NewRelationDialog(QDialog):
                                     tr.TR_RELATION_DIALOG_EMPTY_RELATION_NAME)
             logger.debug('Relation name not specified')
             return
-        central = Pireal.get_service("central")
-        if relation_name in central.get_active_db().table_widget.relations:
+        # central = Pireal.get_service("central")
+        if relation_name in self._central.get_active_db().table_widget.relations:
             QMessageBox.information(
                 self,
                 tr.TR_MSG_ERROR,

--- a/pireal/gui/dialogs/preferences.py
+++ b/pireal/gui/dialogs/preferences.py
@@ -30,13 +30,14 @@ from PyQt5.QtWidgets import QDialogButtonBox
 from PyQt5.QtGui import QFontDatabase
 
 from pireal.core.settings import CONFIG
-from pireal.gui.main_window import Pireal
+# from pireal.gui.main_window import Pireal
 
 
 class Preferences(QDialog):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._central = parent
         self.setWindowTitle('Preferences')
         vbox = QVBoxLayout(self)
 
@@ -87,8 +88,8 @@ class Preferences(QDialog):
         CONFIG.set_value('highlightCurrentLine', self._check_highlight_current_line.isChecked())
         CONFIG.set_value('matchParenthesis', self._check_highlight_braces.isChecked())
 
-        central = Pireal.get_service('central')
-        db = central.get_active_db()
+        # central = Pireal.get_service('central')
+        db = self._central.get_active_db()
         if db is not None:
             qw = db.query_container.currentWidget()
             if qw is not None:

--- a/pireal/gui/lateral_widget.py
+++ b/pireal/gui/lateral_widget.py
@@ -19,24 +19,18 @@
 
 import os
 
-# from PyQt5.QtWidgets import QTreeWidget
 from PyQt5.QtWidgets import QWidget
 from PyQt5.QtWidgets import QSplitter
-# from PyQt5.QtWidgets import QTreeWidgetItem
-# from PyQt5.QtWidgets import QAbstractItemView
 from PyQt5.QtWidgets import QVBoxLayout
 
 from PyQt5.QtQuickWidgets import QQuickWidget
 
 from PyQt5.QtCore import Qt
-# from PyQt5.QtCore import QObject
 from PyQt5.QtCore import QAbstractListModel
-# from PyQt5.QtCore import pyqtProperty
 from PyQt5.QtCore import pyqtSignal as Signal
 from PyQt5.QtCore import QUrl
 
 from pireal import translations as tr
-from pireal.gui.main_window import Pireal
 from pireal.core import settings
 
 
@@ -89,6 +83,7 @@ class LateralWidget(QSplitter):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.db_container = parent
         self.setOrientation(Qt.Vertical)
         # Lista de relaciones de la base de datos
         self._relations_list = RelationListQML()
@@ -99,7 +94,7 @@ class LateralWidget(QSplitter):
         self._results_list.set_title(tr.TR_TABLE_RESULTS)
         self.addWidget(self._results_list)
 
-        Pireal.load_service("lateral_widget", self)
+        # Pireal.load_service("lateral_widget", self)
 
         self._relations_list.itemClicked.connect(
             lambda i: self.relationClicked.emit(i))

--- a/pireal/gui/notification.py
+++ b/pireal/gui/notification.py
@@ -25,8 +25,6 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import QTimer
 
-from pireal.gui.main_window import Pireal
-
 
 class Notification(QWidget):
 
@@ -41,9 +39,6 @@ class Notification(QWidget):
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.clear)
 
-        # Install service
-        Pireal.load_service("notification", self)
-
     def clear(self):
         self.notificator.clear()
 
@@ -51,6 +46,3 @@ class Notification(QWidget):
         if time_out != 0:
             self.timer.start(time_out)
         self.notificator.setText(text)
-
-
-Notification()

--- a/pireal/gui/query_container/editor.py
+++ b/pireal/gui/query_container/editor.py
@@ -26,7 +26,6 @@ from PyQt5.QtGui import QTextCursor
 from PyQt5.QtGui import QFont
 from PyQt5.QtGui import QColor
 from PyQt5.QtGui import QKeySequence
-# from PyQt5.QtGui import QTextOption
 from PyQt5.QtGui import QTextDocument
 
 from PyQt5.QtCore import Qt, QTimer
@@ -36,7 +35,6 @@ from pireal.gui.query_container import (
     sidebar
 )
 from pireal.core.settings import CONFIG
-# from pireal.gui.query_container import snippets
 
 
 class Editor(QPlainTextEdit):

--- a/pireal/gui/start_page.py
+++ b/pireal/gui/start_page.py
@@ -29,7 +29,7 @@ from PyQt5.QtWidgets import QVBoxLayout
 from PyQt5.QtQuick import QQuickView
 from PyQt5.QtCore import QUrl
 from PyQt5.QtCore import QTimer
-from pireal.gui.main_window import Pireal
+# from pireal.gui.main_window import Pireal
 from pireal.core import settings
 
 from pireal.core.settings import CONFIG
@@ -38,8 +38,9 @@ from pireal.core.settings import CONFIG
 class StartPage(QWidget):
     """Lógical para la UI QML de la página principal"""
 
-    def __init__(self):
-        super(StartPage, self).__init__()
+    def __init__(self, parent=None):
+        super(StartPage, self).__init__(parent)
+        self._central = parent
         vbox = QVBoxLayout(self)
         vbox.setContentsMargins(0, 0, 0, 0)
         view = QQuickView()
@@ -60,29 +61,30 @@ class StartPage(QWidget):
         self.__root.removeCurrent.connect(self.__remove_current)
 
     def __open_example(self):
-        central_widget = Pireal.get_service("central")
+        # central_widget = Pireal.get_service("central")
+
         db_filename = os.path.join(settings.EXAMPLES, 'database.pdb')
-        central_widget.open_database(filename=db_filename, remember=False)
+        self._central.open_database(filename=db_filename, remember=False)
         query_filename = os.path.join(settings.EXAMPLES, 'queries.pqf')
-        central_widget.open_query(filename=query_filename, remember=False)
+        self._central.open_query(filename=query_filename, remember=False)
         # Ejecuto las consultas de ejemplo luego de 1.3 segundos
-        QTimer.singleShot(1300, central_widget.execute_queries)
+        QTimer.singleShot(1300, self._central.execute_queries)
 
     def __open_preferences(self):
-        central_widget = Pireal.get_service("central")
-        central_widget.show_settings()
+        # central_widget = Pireal.get_service("central")
+        self._central.show_settings()
 
     def __remove_current(self, path):
-        central_widget = Pireal.get_service("central")
-        central_widget.recent_databases.remove(path)
+        # central_widget = Pireal.get_service("central")
+        self._central.recent_databases.remove(path)
 
     def __open_database(self, path=''):
-        central_widget = Pireal.get_service("central")
-        central_widget.open_database(path)
+        # central_widget = Pireal.get_service("central")
+        self._central.open_database(path)
 
     def __new_database(self):
-        central_widget = Pireal.get_service("central")
-        central_widget.create_database()
+        # central_widget = Pireal.get_service("central")
+        self._central.create_database()
 
     def load_items(self):
         self.__root.clear()

--- a/pireal/gui/table_widget.py
+++ b/pireal/gui/table_widget.py
@@ -35,17 +35,17 @@ from pireal.gui import model
 from pireal.gui import delegate
 
 from pireal import translations as tr
-from pireal.gui.main_window import Pireal
+# from pireal.gui.main_window import Pireal
 
 
 class TableWidget(QSplitter):
 
-    def __init__(self):
-        super(TableWidget, self).__init__()
+    def __init__(self, parent=None):
+        super(TableWidget, self).__init__(parent)
 
         # vbox = QVBoxLayout(self)
         # vbox.setContentsMargins(0, 0, 0, 0)
-
+        self.db_container = parent
         self._tabs = QTabWidget()
         self._tabs.setAutoFillBackground(True)
         p = self._tabs.palette()
@@ -82,7 +82,7 @@ class TableWidget(QSplitter):
         # self.setContextMenuPolicy(Qt.CustomContextMenu)
         # self.customContextMenuRequested.connect(self._show_menu)
 
-        lateral_widget = Pireal.get_service("lateral_widget")
+        lateral_widget = self.db_container.lateral_widget
         lateral_widget.resultClicked.connect(self._on_result_list_clicked)
         lateral_widget.resultSelectionChanged.connect(
             lambda index: self.stacked_result.setCurrentIndex(index))
@@ -132,8 +132,7 @@ class TableWidget(QSplitter):
         menu.exec_(self.mapToGlobal(position))
 
     def __new_relation(self):
-        central_service = Pireal.get_service("central")
-        central_service.create_new_relation()
+        self.db_container._central.create_new_relation()
 
     def count(self):
         return self.stacked.count()

--- a/pireal/main.py
+++ b/pireal/main.py
@@ -74,10 +74,6 @@ def start_pireal():
 
     # TODO: Load stylesheet
 
-    # FIXME: Cambiar la forma de esto
-    from pireal.gui import central_widget  # noqa
-    from pireal.gui import notification  # noqa
-
     pireal_gui = main_window.Pireal()
     pireal_gui.show()
 

--- a/pireal/translations.py
+++ b/pireal/translations.py
@@ -156,3 +156,7 @@ TR_DB_DIALOG_DB_FILENAME = tr('Pireal', 'Filename:')
 TR_DB_DIALOG_SELECT_FOLDER = tr('Pireal', 'Select Folder')
 
 TR_DB_FILE_EMPTY = tr('Pireal', 'The file <b>{}</b> is empty, aborting.')
+
+# Search widget
+TR_BTN_FIND_PREVIOUS = tr('Pireal', 'Find Previous')
+TR_BTN_FIND_NEXT = tr('Pireal', 'Find Next')


### PR DESCRIPTION
Actualmente todos los "servicios" (*central_widget*, *lateral_widget*, etc) se autoregistran en el componente principal (*Pireal*). 

La idea justamente de este PR es cambiar esta forma, crear los componentes de la "forma normal". 

Al refactorizar esto, se encontraron problemas, importaciones circulares, duplicación de instancias(?. Se deberá rehacer la jerarquía de componentes y describir cada uno, a partir de eso realizar la implementación.  

### To Do
- [x] Objects UI Hierarchy diagram
- [x] Description for each object
- [x] Remove `get_service`, `load_service` and friends
- [x] Create objects as attributes
- [x] Remove unused/commented code
- [ ] ~~**Refactor Objects Hierarchy**~~
