### PR TITLE
Ordered set instead built-in set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ installation_on_windows: &installation_on_windows
     - choco install python --version 3.7.4
     - python --version
     - python -m pip install --upgrade pip
-    - pip3 install --upgrade pytest
+    - pip3 install --upgrade pytest ordered-set
 
 install: pip --version  # Avoid install with pip install -r requirements.txt
 
@@ -47,7 +47,7 @@ jobs:
       name: unit test
       before_install:
         - pip install pip --upgrade
-        - pip install pytest pytest-cov
+        - pip install pytest pytest-cov ordered-set
       script: make test
 
     - stage: Test
@@ -66,14 +66,14 @@ jobs:
             - libxkbcommon-x11-0
       name: unit test user interface
       before_install:
-        - pip install pyqt5 pytest pytest-qt
+        - pip install pyqt5 pytest pytest-qt ordered-set
       script: make test-gui
 
     - stage: Integration Test
       name: integration test
       before_install:
         - pip install pip --upgrade
-        - pip install pytest
+        - pip install pytest ordered-set
       before_script: make clean
       script: make test-integration
 
@@ -92,4 +92,5 @@ jobs:
         - pip install pytest
         - pip install pytest-cov
         - pip install coveralls
+        - pip install ordered-set
       script: coveralls

--- a/pireal/core/relation.py
+++ b/pireal/core/relation.py
@@ -23,6 +23,8 @@
 import re
 import itertools
 
+from ordered_set import OrderedSet
+
 from pireal.core.rtypes import RelationStr
 
 IS_VALID_FIELD_NAME = re.compile("^[_á-úa-zA-Z][_á-úa-zA-Z0-9]*$")
@@ -100,7 +102,7 @@ def union_compatible(operation):
 class Relation(object):
 
     def __init__(self):
-        self.content = set()
+        self.content = OrderedSet()
         self._header = []
         self.name = ""
         self._null_count = 1
@@ -138,10 +140,11 @@ class Relation(object):
     def append_row(self):
         """Agrega una fila/tupla al final"""
 
-        null_row = ["null ({})".format(self._null_count)
-                    for i in range(self.degree())]
-        self.insert(tuple(null_row))
-        self._null_count += 1
+        nulls = []
+        for _ in range(self.degree()):
+            nulls.append('null ({})'.format(self._null_count))
+            self._null_count += 1
+        self.insert(tuple(nulls))
 
     def cardinality(self):
         """Devuelve la cantidad de filas de la relación"""
@@ -331,6 +334,7 @@ class Relation(object):
 
     def __str__(self):
         """Magic method. Returns a representation of the relation"""
+        print()
 
         header = ""
         for field in self._header:
@@ -345,3 +349,6 @@ class Relation(object):
             content += "|\n"
 
         return header + content
+
+    def __repr__(self):
+        return self.__str__()

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
         ]
     },
     classifiers=CLASSIFIERS,
+    install_requires=['ordered-set'],
     scripts=['bin/pireal'],
     cmdclass={'install': CustomInstall}
 )

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -71,13 +71,6 @@ def test_get_files_from_folder(tmpdir):
 
 
 def test_generate_database():
-    # XXX: acerca de este test
-    # lo ideal seria assertear el resultado con lo esperado pero
-    # no como tupla sino como un string.
-    # La implementación actual de Relation.content es un set
-    # (para aprovechar las operaciones sobre conjuntos),
-    # por lo tanto no importa el órden. Considerar mejorar eso
-
     r1 = relation.Relation()
     r1.header = ['id', 'name']
     r1.content.add(('1', 'gabox'))
@@ -87,19 +80,14 @@ def test_generate_database():
     r2.header = ['id', 'skill']
     r2.content = {('23', 'games')}
 
-    relations = OrderedDict()
+    relations = {}
     relations['people'] = r1
     relations['skills'] = r2
-    expected = (
-        '@people:id,name',
-        '1,gabox',
-        '23,rodrigo',
-        '@skills:id,skill',
-        '23,games'
-    )
+
+    expected = '@people:id,name\n1,gabox\n23,rodrigo\n\n@skills:id,skill\n23,games\n'
     result = file_manager.generate_database(relations)
-    for expec in expected:
-        assert expec in result
+
+    assert result == expected
 
 
 def test_database_text_content_simple_content():

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -312,12 +312,46 @@ def test_difference():
     assert new.cardinality() == 5
 
 
-# def test_str(relation_fixture):
-#     _, _, r3 = relation_fixture
-#     expected = ("|     date     |\n"
-#                 "----------------\n"
-#                 "|  2012-07-09  |\n"
-#                 "|  1998-12-09  |\n"
-#                 "|  2015-12-12  |\n")
-#     # assert str(r3) == expected
-#     # FIXME: el orden
+def test_update_relation():
+    r = relation.Relation()
+    r.header = ['id', 'name']
+    r.content.add(('21', 'Rodrigo'))
+    r.content.add(('1', 'gabox'))
+
+    expected = relation.OrderedSet([
+        ('21', 'Rodrigo'),
+        ('1', 'Gabriel')
+    ])
+
+    r.update(1, 1, 'Gabriel')
+
+    assert r.content == expected
+
+
+def test_append_row():
+    r = relation.Relation()
+    r.header = ['id', 'name']
+    r.content.add(('21', 'Rodrigo'))
+    r.content.add(('1', 'gabox'))
+
+    expected = relation.OrderedSet([
+        ('21', 'Rodrigo'),
+        ('1', 'gabox'),
+        ('null (1)', 'null (2)'),
+        ('null (3)', 'null (4)')
+    ])
+
+    r.append_row()
+    r.append_row()
+
+    assert r.content == expected
+
+
+def test_str_repr():
+    r = relation.Relation()
+    r.header = ['id', 'name']
+    r.content.add(('21', 'Rodrigo'))
+
+    expected = '|      id      |     name     |\n-------------------------------\n|      21      |   Rodrigo    |\n'
+    assert r.__str__() == expected
+    assert r.__repr__() == expected


### PR DESCRIPTION
Se agrega el package `ordered-set` para mantener el órden de las tuplas.
Este cambio es importante ya que nos permite realizar más tests en donde faltaba y nos da confianza en las operaciones sobre conjuntos.

Si bien el set built-in de python nos sirvió, este es un problema de la vida real en donde necesitamos mantener el órden de inserción.